### PR TITLE
Load pulse.el explicitly

### DIFF
--- a/quoted-scratch.el
+++ b/quoted-scratch.el
@@ -41,6 +41,7 @@
 
 (require 'json)
 (require 'url)
+(require 'pulse)
 
 (defgroup quoted-scratch nil
   "Customization group for `quoted-scratch'."


### PR DESCRIPTION
Because `pulse-momentary-highlight-region` is not an autoload function
on older Emacs(< 25)